### PR TITLE
[wpilibc] DLM: Rename console log entry to "console"

### DIFF
--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -309,7 +309,7 @@ void Thread::StopNTLog() {
 void Thread::StartConsoleLog() {
   if (!m_consoleLoggerEnabled && RobotBase::IsReal()) {
     m_consoleLoggerEnabled = true;
-    m_consoleLogger = {"/home/lvuser/FRC_UserProgram.log", m_log, "output"};
+    m_consoleLogger = {"/home/lvuser/FRC_UserProgram.log", m_log, "console"};
   }
 }
 


### PR DESCRIPTION
This matches Java.